### PR TITLE
Update readme for schedule_logger sample

### DIFF
--- a/ballerina-integrator/scheduled-logger/README.md
+++ b/ballerina-integrator/scheduled-logger/README.md
@@ -1,14 +1,14 @@
 # Scheduled Logger (Automation Task)
 
 ## Description
-A scheduled task that logs the current timestamp every five seconds. Useful for tracking time-based executions.
+A scheduled task that logs the current timestamp every minute. Useful for tracking time-based executions.
 
 ## Usage Instructions
 
 ### Deploy on **Devant**
 
 1. Deploy this integration on **Devant** as an **Automation**.
-2. Once deployed, it will log the current timestamp every five seconds.
+2. Once deployed, it will log the current timestamp every minute.
 
 ## References
 


### PR DESCRIPTION
## Purpose
The current readme suggests the user to deploy and schedule the automation for every 5 seconds. But the lowest time interval supported for scheduling in devant is one minute. Hence updated the readme to instruct the user to schedule it to run every minute


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Scheduled Logger documentation to reflect the new execution frequency of one minute instead of the previous five-second interval
* Updated deployment instructions to align with the revised scheduling configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->