### PR TITLE
Update the MI samples to run with MI 4.6.0

### DIFF
--- a/integrator-mi-profile/APITesting/pom.xml
+++ b/integrator-mi-profile/APITesting/pom.xml
@@ -355,7 +355,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/ContentBasedRouting/pom.xml
+++ b/integrator-mi-profile/ContentBasedRouting/pom.xml
@@ -354,7 +354,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -391,15 +391,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/DatabasePolling/pom.xml
+++ b/integrator-mi-profile/DatabasePolling/pom.xml
@@ -391,15 +391,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
   <dependencies>

--- a/integrator-mi-profile/EmailService/pom.xml
+++ b/integrator-mi-profile/EmailService/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>synapse-unit-test-maven-plugin</artifactId>
-                <version>5.2.90</version>
+                <version>5.4.16</version>
                 <executions>
                     <execution>
                         <id>synapse-unit-test</id>
@@ -392,7 +392,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
         <car.plugin.version>5.2.100</car.plugin.version>
         <test.server.type>local</test.server.type>
@@ -400,7 +400,7 @@
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
     <dependencies>

--- a/integrator-mi-profile/ExceptionHandling/pom.xml
+++ b/integrator-mi-profile/ExceptionHandling/pom.xml
@@ -353,7 +353,7 @@
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>synapse-unit-test-maven-plugin</artifactId>
-                <version>5.2.90</version>
+                <version>5.4.16</version>
                 <executions>
                     <execution>
                         <id>synapse-unit-test</id>
@@ -390,15 +390,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-        <car.plugin.version>5.2.97</car.plugin.version>
+        <car.plugin.version>5.4.16</car.plugin.version>
         <test.server.type>local</test.server.type>
         <test.server.host>localhost</test.server.host>
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
     <dependencies>

--- a/integrator-mi-profile/FetchSalesForceAccounts/pom.xml
+++ b/integrator-mi-profile/FetchSalesForceAccounts/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/FileTransfer/pom.xml
+++ b/integrator-mi-profile/FileTransfer/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/GuaranteedDelivery/pom.xml
+++ b/integrator-mi-profile/GuaranteedDelivery/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/HeaderBasedRouting/pom.xml
+++ b/integrator-mi-profile/HeaderBasedRouting/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/HelloDocker/pom.xml
+++ b/integrator-mi-profile/HelloDocker/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/HelloWorldService/pom.xml
+++ b/integrator-mi-profile/HelloWorldService/pom.xml
@@ -355,7 +355,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/JMSIntegration/pom.xml
+++ b/integrator-mi-profile/JMSIntegration/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/KafkaConsumerAndProducer/pom.xml
+++ b/integrator-mi-profile/KafkaConsumerAndProducer/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>synapse-unit-test-maven-plugin</artifactId>
-                <version>5.2.90</version>
+                <version>5.4.16</version>
                 <executions>
                     <execution>
                         <id>synapse-unit-test</id>
@@ -392,7 +392,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
         <car.plugin.version>5.2.100</car.plugin.version>
         <test.server.type>local</test.server.type>
@@ -400,7 +400,7 @@
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
     <dependencies>

--- a/integrator-mi-profile/MessageFiltering/pom.xml
+++ b/integrator-mi-profile/MessageFiltering/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>synapse-unit-test-maven-plugin</artifactId>
-                <version>5.2.90</version>
+                <version>5.4.16</version>
                 <executions>
                     <execution>
                         <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-        <car.plugin.version>5.2.97</car.plugin.version>
+        <car.plugin.version>5.4.16</car.plugin.version>
         <test.server.type>local</test.server.type>
         <test.server.host>localhost</test.server.host>
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
 </project>

--- a/integrator-mi-profile/PeriodicalScheduledTasks/pom.xml
+++ b/integrator-mi-profile/PeriodicalScheduledTasks/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/ProtocolSwitching/pom.xml
+++ b/integrator-mi-profile/ProtocolSwitching/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
   <dependencies>

--- a/integrator-mi-profile/ProxyingaRESTService/pom.xml
+++ b/integrator-mi-profile/ProxyingaRESTService/pom.xml
@@ -355,7 +355,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/ProxyingaRESTService/pom.xml
+++ b/integrator-mi-profile/ProxyingaRESTService/pom.xml
@@ -403,4 +403,18 @@
     <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.wso2.integration.connector</groupId>
+      <artifactId>mi-connector-http</artifactId>
+      <version>0.1.14</version>
+      <type>zip</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 </project>

--- a/integrator-mi-profile/ProxyingaRESTService/src/main/wso2mi/artifacts/local-entries/UsersHttpEPConnection.xml
+++ b/integrator-mi-profile/ProxyingaRESTService/src/main/wso2mi/artifacts/local-entries/UsersHttpEPConnection.xml
@@ -2,13 +2,18 @@
 <localEntry key="UsersHttpEPConnection" xmlns="http://ws.apache.org/ns/synapse">
   <http.init>
     <connectionType>HTTPS</connectionType>
-    <baseUrl>https://reqres.in/api</baseUrl>
+    <baseUrl>https://jsonplaceholder.typicode.com</baseUrl>
+    <certificateConfigurable/>
     <authType>None</authType>
+    <timeoutDuration/>
     <timeoutAction>Never</timeoutAction>
+    <retryErrorCodes/>
     <retryCount>0</retryCount>
     <retryDelay>0</retryDelay>
+    <suspendErrorCodes/>
     <suspendInitialDuration>-1</suspendInitialDuration>
     <suspendProgressionFactor>1</suspendProgressionFactor>
+    <suspendMaximumDuration/>
     <name>UsersHttpEPConnection</name>
   </http.init>
 </localEntry>

--- a/integrator-mi-profile/ProxyingaRESTService/src/test/wso2mi/UserInfoRestAPITest.xml
+++ b/integrator-mi-profile/ProxyingaRESTService/src/test/wso2mi/UserInfoRestAPITest.xml
@@ -1,32 +1,268 @@
 <unit-test>
-  <artifacts>
-    <test-artifact>
-      <artifact>src/main/wso2mi/artifacts/apis/UserInfoRestAPI.xml</artifact>
-    </test-artifact>
-    <supportive-artifacts>
-      <artifact>src/main/wso2mi/artifacts/local-entries/UsersHttpEPConnection.xml</artifact>
-    </supportive-artifacts>
-    <registry-resources></registry-resources>
-    <connector-resources>
-      <connector-resource>src/main/wso2mi/resources/connectors/mi-connector-http-0.1.7.zip</connector-resource>
-    </connector-resources>
-  </artifacts>
-  <test-cases>
-    <test-case name="ProxyingREST">
-      <input>
-        <request-path>/users</request-path>
-        <request-method>GET</request-method>
-      </input>
-      <assertions>
-        <assertEquals>
-          <actual>$body</actual>
-          <expected><![CDATA[{"page":1,"per_page":6,"total":12,"total_pages":2,"data":[{"id":1,"email":"george.bluth@reqres.in","first_name":"George","last_name":"Bluth","avatar":"https://reqres.in/img/faces/1-image.jpg"},{"id":2,"email":"janet.weaver@reqres.in","first_name":"Janet","last_name":"Weaver","avatar":"https://reqres.in/img/faces/2-image.jpg"},{"id":3,"email":"emma.wong@reqres.in","first_name":"Emma","last_name":"Wong","avatar":"https://reqres.in/img/faces/3-image.jpg"},{"id":4,"email":"eve.holt@reqres.in","first_name":"Eve","last_name":"Holt","avatar":"https://reqres.in/img/faces/4-image.jpg"},{"id":5,"email":"charles.morris@reqres.in","first_name":"Charles","last_name":"Morris","avatar":"https://reqres.in/img/faces/5-image.jpg"},{"id":6,"email":"tracey.ramos@reqres.in","first_name":"Tracey","last_name":"Ramos","avatar":"https://reqres.in/img/faces/6-image.jpg"}],"support":{"url":"https://contentcaddy.io?utm_source=reqres&utm_medium=json&utm_campaign=referral","text":"Tired of writing endless social media content? Let Content Caddy generate it for you."}}]]></expected>
-          <message>Proxying REST test case failed.</message>
-        </assertEquals>
-      </assertions>
-    </test-case>
-  </test-cases>
-  <mock-services>
-    <mock-service>src/test/resources/mock-services/ProxyingRESTMockService.xml</mock-service>
-  </mock-services>
+    <artifacts>
+        <test-artifact>
+            <artifact>src/main/wso2mi/artifacts/apis/UserInfoRestAPI.xml</artifact>
+        </test-artifact>
+        <supportive-artifacts>
+            <artifact>src/main/wso2mi/artifacts/local-entries/UsersHttpEPConnection.xml</artifact>
+        </supportive-artifacts>
+        <registry-resources>
+        </registry-resources>
+        <connector-resources>
+            <connector-resource>mi-connector-http-0.1.14</connector-resource>
+        </connector-resources>
+    </artifacts>
+    <test-cases>
+        <test-case name="ProxyingREST">
+            <input>
+                <request-path>/users</request-path>
+                <request-method>GET</request-method>
+                <request-protocol>http</request-protocol>
+            </input>
+            <assertions>
+                <assertEquals>
+                    <actual>$body</actual>
+                    <expected><![CDATA[[
+  {
+    "id": 1,
+    "name": "Leanne Graham",
+    "username": "Bret",
+    "email": "Sincere@april.biz",
+    "address": {
+      "street": "Kulas Light",
+      "suite": "Apt. 556",
+      "city": "Gwenborough",
+      "zipcode": "92998-3874",
+      "geo": {
+        "lat": "-37.3159",
+        "lng": "81.1496"
+      }
+    },
+    "phone": "1-770-736-8031 x56442",
+    "website": "hildegard.org",
+    "company": {
+      "name": "Romaguera-Crona",
+      "catchPhrase": "Multi-layered client-server neural-net",
+      "bs": "harness real-time e-markets"
+    }
+  },
+  {
+    "id": 2,
+    "name": "Ervin Howell",
+    "username": "Antonette",
+    "email": "Shanna@melissa.tv",
+    "address": {
+      "street": "Victor Plains",
+      "suite": "Suite 879",
+      "city": "Wisokyburgh",
+      "zipcode": "90566-7771",
+      "geo": {
+        "lat": "-43.9509",
+        "lng": "-34.4618"
+      }
+    },
+    "phone": "010-692-6593 x09125",
+    "website": "anastasia.net",
+    "company": {
+      "name": "Deckow-Crist",
+      "catchPhrase": "Proactive didactic contingency",
+      "bs": "synergize scalable supply-chains"
+    }
+  },
+  {
+    "id": 3,
+    "name": "Clementine Bauch",
+    "username": "Samantha",
+    "email": "Nathan@yesenia.net",
+    "address": {
+      "street": "Douglas Extension",
+      "suite": "Suite 847",
+      "city": "McKenziehaven",
+      "zipcode": "59590-4157",
+      "geo": {
+        "lat": "-68.6102",
+        "lng": "-47.0653"
+      }
+    },
+    "phone": "1-463-123-4447",
+    "website": "ramiro.info",
+    "company": {
+      "name": "Romaguera-Jacobson",
+      "catchPhrase": "Face to face bifurcated interface",
+      "bs": "e-enable strategic applications"
+    }
+  },
+  {
+    "id": 4,
+    "name": "Patricia Lebsack",
+    "username": "Karianne",
+    "email": "Julianne.OConner@kory.org",
+    "address": {
+      "street": "Hoeger Mall",
+      "suite": "Apt. 692",
+      "city": "South Elvis",
+      "zipcode": "53919-4257",
+      "geo": {
+        "lat": "29.4572",
+        "lng": "-164.2990"
+      }
+    },
+    "phone": "493-170-9623 x156",
+    "website": "kale.biz",
+    "company": {
+      "name": "Robel-Corkery",
+      "catchPhrase": "Multi-tiered zero tolerance productivity",
+      "bs": "transition cutting-edge web services"
+    }
+  },
+  {
+    "id": 5,
+    "name": "Chelsey Dietrich",
+    "username": "Kamren",
+    "email": "Lucio_Hettinger@annie.ca",
+    "address": {
+      "street": "Skiles Walks",
+      "suite": "Suite 351",
+      "city": "Roscoeview",
+      "zipcode": "33263",
+      "geo": {
+        "lat": "-31.8129",
+        "lng": "62.5342"
+      }
+    },
+    "phone": "(254)954-1289",
+    "website": "demarco.info",
+    "company": {
+      "name": "Keebler LLC",
+      "catchPhrase": "User-centric fault-tolerant solution",
+      "bs": "revolutionize end-to-end systems"
+    }
+  },
+  {
+    "id": 6,
+    "name": "Mrs. Dennis Schulist",
+    "username": "Leopoldo_Corkery",
+    "email": "Karley_Dach@jasper.info",
+    "address": {
+      "street": "Norberto Crossing",
+      "suite": "Apt. 950",
+      "city": "South Christy",
+      "zipcode": "23505-1337",
+      "geo": {
+        "lat": "-71.4197",
+        "lng": "71.7478"
+      }
+    },
+    "phone": "1-477-935-8478 x6430",
+    "website": "ola.org",
+    "company": {
+      "name": "Considine-Lockman",
+      "catchPhrase": "Synchronised bottom-line interface",
+      "bs": "e-enable innovative applications"
+    }
+  },
+  {
+    "id": 7,
+    "name": "Kurtis Weissnat",
+    "username": "Elwyn.Skiles",
+    "email": "Telly.Hoeger@billy.biz",
+    "address": {
+      "street": "Rex Trail",
+      "suite": "Suite 280",
+      "city": "Howemouth",
+      "zipcode": "58804-1099",
+      "geo": {
+        "lat": "24.8918",
+        "lng": "21.8984"
+      }
+    },
+    "phone": "210.067.6132",
+    "website": "elvis.io",
+    "company": {
+      "name": "Johns Group",
+      "catchPhrase": "Configurable multimedia task-force",
+      "bs": "generate enterprise e-tailers"
+    }
+  },
+  {
+    "id": 8,
+    "name": "Nicholas Runolfsdottir V",
+    "username": "Maxime_Nienow",
+    "email": "Sherwood@rosamond.me",
+    "address": {
+      "street": "Ellsworth Summit",
+      "suite": "Suite 729",
+      "city": "Aliyaview",
+      "zipcode": "45169",
+      "geo": {
+        "lat": "-14.3990",
+        "lng": "-120.7677"
+      }
+    },
+    "phone": "586.493.6943 x140",
+    "website": "jacynthe.com",
+    "company": {
+      "name": "Abernathy Group",
+      "catchPhrase": "Implemented secondary concept",
+      "bs": "e-enable extensible e-tailers"
+    }
+  },
+  {
+    "id": 9,
+    "name": "Glenna Reichert",
+    "username": "Delphine",
+    "email": "Chaim_McDermott@dana.io",
+    "address": {
+      "street": "Dayna Park",
+      "suite": "Suite 449",
+      "city": "Bartholomebury",
+      "zipcode": "76495-3109",
+      "geo": {
+        "lat": "24.6463",
+        "lng": "-168.8889"
+      }
+    },
+    "phone": "(775)976-6794 x41206",
+    "website": "conrad.com",
+    "company": {
+      "name": "Yost and Sons",
+      "catchPhrase": "Switchable contextually-based project",
+      "bs": "aggregate real-time technologies"
+    }
+  },
+  {
+    "id": 10,
+    "name": "Clementina DuBuque",
+    "username": "Moriah.Stanton",
+    "email": "Rey.Padberg@karina.biz",
+    "address": {
+      "street": "Kattie Turnpike",
+      "suite": "Suite 198",
+      "city": "Lebsackbury",
+      "zipcode": "31428-2261",
+      "geo": {
+        "lat": "-38.2386",
+        "lng": "57.2232"
+      }
+    },
+    "phone": "024-648-3804",
+    "website": "ambrose.net",
+    "company": {
+      "name": "Hoeger LLC",
+      "catchPhrase": "Centralized empowering task-force",
+      "bs": "target end-to-end models"
+    }
+  }
+]]]></expected>
+                    <message>Proxying REST test case failed.</message>
+                </assertEquals>
+            </assertions>
+        </test-case>
+    
+    
+    
+    </test-cases>
+    <mock-services>
+        <mock-service>src/test/resources/mock-services/ProxyingRESTMockService.xml</mock-service>
+    </mock-services>
 </unit-test>

--- a/integrator-mi-profile/ProxyingaSOAPService/pom.xml
+++ b/integrator-mi-profile/ProxyingaSOAPService/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/RESTDataService/pom.xml
+++ b/integrator-mi-profile/RESTDataService/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
   <dependencies>

--- a/integrator-mi-profile/RESTtoSOAPConversion/pom.xml
+++ b/integrator-mi-profile/RESTtoSOAPConversion/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/RabbitMQIntegration/pom.xml
+++ b/integrator-mi-profile/RabbitMQIntegration/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
   <dependencies>

--- a/integrator-mi-profile/StudentsDataService/pom.xml
+++ b/integrator-mi-profile/StudentsDataService/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,7 +393,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
     <car.plugin.version>5.2.100</car.plugin.version>
     <test.server.type>local</test.server.type>
@@ -401,7 +401,7 @@
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
   <dependencies>

--- a/integrator-mi-profile/SynapseExpressions/pom.xml
+++ b/integrator-mi-profile/SynapseExpressions/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>synapse-unit-test-maven-plugin</artifactId>
-                <version>5.2.90</version>
+                <version>5.4.16</version>
                 <executions>
                     <execution>
                         <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-        <car.plugin.version>5.2.97</car.plugin.version>
+        <car.plugin.version>5.4.16</car.plugin.version>
         <test.server.type>local</test.server.type>
         <test.server.host>localhost</test.server.host>
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
     <dependencies>

--- a/integrator-mi-profile/UnitTestTutorial/pom.xml
+++ b/integrator-mi-profile/UnitTestTutorial/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>

--- a/integrator-mi-profile/XMLToJSONTransformation/pom.xml
+++ b/integrator-mi-profile/XMLToJSONTransformation/pom.xml
@@ -355,7 +355,7 @@
         <plugin>
             <groupId>org.wso2.maven</groupId>
             <artifactId>synapse-unit-test-maven-plugin</artifactId>
-            <version>5.2.90</version>
+            <version>5.4.16</version>
             <executions>
             <execution>
                 <id>synapse-unit-test</id>
@@ -392,15 +392,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.scm.id>integration-project</project.scm.id>
-        <project.runtime.version>4.4.0</project.runtime.version>
+        <project.runtime.version>4.6.0</project.runtime.version>
         <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-        <car.plugin.version>5.2.97</car.plugin.version>
+        <car.plugin.version>5.4.16</car.plugin.version>
         <test.server.type>local</test.server.type>
         <test.server.host>localhost</test.server.host>
         <test.server.port>9008</test.server.port>
         <test.server.path>/</test.server.path>
         <test.server.version>${project.runtime.version}</test.server.version>
-        <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+        <testServerDownloadLink></testServerDownloadLink>
         <maven.test.skip>false</maven.test.skip>
     </properties>
     <dependencies>

--- a/integrator-mi-profile/XMLtoJSONMapping/pom.xml
+++ b/integrator-mi-profile/XMLtoJSONMapping/pom.xml
@@ -356,7 +356,7 @@
       <plugin>
         <groupId>org.wso2.maven</groupId>
         <artifactId>synapse-unit-test-maven-plugin</artifactId>
-        <version>5.2.90</version>
+        <version>5.4.16</version>
         <executions>
           <execution>
             <id>synapse-unit-test</id>
@@ -393,15 +393,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.scm.id>integration-project</project.scm.id>
-    <project.runtime.version>4.4.0</project.runtime.version>
+    <project.runtime.version>4.6.0</project.runtime.version>
     <dockerfile.base.image>wso2/wso2mi:${project.runtime.version}</dockerfile.base.image>
-    <car.plugin.version>5.2.97</car.plugin.version>
+    <car.plugin.version>5.4.16</car.plugin.version>
     <test.server.type>local</test.server.type>
     <test.server.host>localhost</test.server.host>
     <test.server.port>9008</test.server.port>
     <test.server.path>/</test.server.path>
     <test.server.version>${project.runtime.version}</test.server.version>
-    <testServerDownloadLink>https://github.com/wso2/micro-integrator/releases/download/v${test.server.version}/wso2mi-${test.server.version}.zip</testServerDownloadLink>
+    <testServerDownloadLink></testServerDownloadLink>
     <maven.test.skip>false</maven.test.skip>
   </properties>
 </project>


### PR DESCRIPTION
## Purpose
Update the MI samples to run with MI 4.6.0.

The following changes have been made.
- Updated the runtime version
- Updated the car plugin and unit test plugin version
- Fixed test failures in ProxyingaRESTService sample