### PR TITLE
Use root-level types in the Pricefx connector sample

### DIFF
--- a/integrator-default-profile/connectors/pricefx_connector_sample/automation.bal
+++ b/integrator-default-profile/connectors/pricefx_connector_sample/automation.bal
@@ -1,9 +1,9 @@
 import ballerina/log;
-import ballerinax/pricefx.oas;
+import ballerinax/pricefx;
 
 public function main() returns error? {
     do {
-        oas:ListPriceListTypesEnvelope priceListTypes = check pricefxClient->listPriceListTypes();
+        pricefx:ListPriceListTypesEnvelope priceListTypes = check pricefxClient->listPriceListTypes();
         log:printInfo(priceListTypes.toString());
     } on fail error e {
         log:printError("Error occurred", 'error = e);


### PR DESCRIPTION
## Purpose

Follow-up to #150, same change as #152 for the SAP connector sample. From `ballerinax/pricefx` **0.2.0** (ballerina-platform/module-ballerinax-pricefx#7), every API type is available from the package root, so the sample no longer needs the extra `oas` submodule import:

```ballerina
import ballerinax/pricefx;

pricefx:ListPriceListTypesEnvelope priceListTypes = check pricefxClient->listPriceListTypes();
```

**Note:** should be merged once `ballerinax/pricefx` 0.2.0 is published to Ballerina Central.